### PR TITLE
_get_nb_zone() function is aware of same zones declared under different view

### DIFF
--- a/octodns_netbox_dns/__init__.py
+++ b/octodns_netbox_dns/__init__.py
@@ -82,10 +82,10 @@ class NetBoxDNSSource(octodns.provider.base.BaseProvider):
         self._ttl = ttl
         self.replace_duplicates = replace_duplicates
 
-    def _get_nb_zone(self, name: str, view: str) -> pynetbox.core.response.Record:
-        """Given a zone name, look it up in NetBox.
+    def _get_nb_zone(self, name: str, view: str | None) -> pynetbox.core.response.Record:
+        """Given a zone name and a view name, look it up in NetBox.
            Raises: pynetbox.RequestError if declared view is not existant"""
-        view_name = "null" if not view else view.name
+        view_name = "null" if not view else view
         nb_zone = self._api.plugins.netbox_dns.zones.get(name=name[:-1], view=view_name)
         
         return nb_zone
@@ -100,7 +100,7 @@ class NetBoxDNSSource(octodns.provider.base.BaseProvider):
 
         records = {}
 
-        nb_zone = self._get_nb_zone(zone.name, view=self._nb_view)
+        nb_zone = self._get_nb_zone(zone.name, view=self._nb_view.name)
 
         nb_records = self._api.plugins.netbox_dns.records.filter(zone_id=nb_zone.id)
         for nb_record in nb_records:
@@ -211,7 +211,7 @@ class NetBoxDNSSource(octodns.provider.base.BaseProvider):
             f"_apply: zone={plan.desired.name}, len(changes)={len(plan.changes)}"
         )
 
-        nb_zone = self._get_nb_zone(plan.desired.name, view=self._nb_view)
+        nb_zone = self._get_nb_zone(plan.desired.name, view=self._nb_view.name)
 
         for change in plan.changes:
             match change:


### PR DESCRIPTION
this PR simplifies _get_nb_zone() function by adding "view" parameter.

In order to deal the same zone declared under different views it is necessary to declare multiple NetBoxDNSSource providers each with it's view in OctoDNS configuration file.