### PR TITLE
Several fixes for new pynetbox and Netbox

### DIFF
--- a/octodns_netbox_dns/__init__.py
+++ b/octodns_netbox_dns/__init__.py
@@ -86,7 +86,7 @@ class NetBoxDNSSource(octodns.provider.base.BaseProvider):
         """Given a zone name and a view name, look it up in NetBox.
            Raises: pynetbox.RequestError if declared view is not existant"""
         view = "null" if not view else view
-        nb_zone = self._api.plugins.netbox_dns.zones.get(name=name[:-1], view=view)
+        nb_zone = self._api.plugins.netbox_dns.zones.get(name=name[:-1], view_id=view.id)
         
         return nb_zone
 

--- a/octodns_netbox_dns/__init__.py
+++ b/octodns_netbox_dns/__init__.py
@@ -110,10 +110,18 @@ class NetBoxDNSSource(octodns.provider.base.BaseProvider):
             name = nb_record.name
             if name == "@":
                 name = ""
+
+            nb_zone_default_ttl = nb_zone.default_ttl
+            if nb_record.ttl:
+                nb_ttl = nb_record.ttl
+            elif nb_record.type == "NS":
+                nb_ttl = nb_zone.soa_refresh
+            else:
+                nb_ttl = nb_zone_default_ttl
             data = {
                 "name": name,
                 "type": nb_record.type,
-                "ttl": nb_record.ttl,
+                "ttl": nb_ttl,
                 "values": [],
             }
             rdata = dns.rdata.from_text("IN", nb_record.type, nb_record.value)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,13 +8,7 @@ authors = ["Jeffrey C. Ollie <jeff@ocjtech.us>"]
 python = "^3.10"
 octodns = "^0.9.17"
 
-# There's a bug in pynetbox that prevents update & delete operations on plugin REST API endpoints.
-# Until pull request #426 is merged I recommend using my fork of pynetbox which has #426 applied to
-# the version 6.6.2 of pynetbox (the original pull request is against an older version).
-#
-# pynetbox = "^6.6.2"
-#
-pynetbox = { git = "https://github.com/jcollie/pynetbox.git", rev = "35449e0e87105d9a6170bcc333d6a1882c945cd0" }
+pynetbox = "^7.0.1"
 
 dnspython = "^2.2.1"
 


### PR DESCRIPTION
Hi, I've tried to deploy your script with octoDNS and ran into several issues. 

1) on line 89 netbox is failing with error 400, because you are searching for zone and using all values of the view as search parameters. Now it's searching only with zone name and View ID to avoid errors.

2) OctoDNS was failing with Nameserver records not having TTL values (which is unavoidable as far as i was trying). It also doesn't respect the default TTL value for records. Now it's using default values for records and soa_refresh for NS records. 

3) pynetbox already merged the #426 pull request and it seems to work OK with the upstream library.

I had time to only test with PTR records and not standart domains, but I hope this shouldn't break those. 
Also sorry I'm sending pull request with 3 changes, I wanted to contribute my fixes and I'm running out of time on that... I hope it will be helpful anyway:)

Thanks for the script, it saved me a lot of time even with some debugging!